### PR TITLE
Update Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,11 @@ This repository manages job requests between the web UI and the observatory site
 
 ## Description
 
-(insert description here)
+Users can create new job requests, such as pointing a mount or exposing a camera, 
+which observatories can then carry out.
+
+Observatories can retrieve new jobs to perform, update a job's status as it changes, and retrieve recent jobs regardless of status. Use of these API endpoints is mostly found in 
+[the observatory repository](https://github.com/LCOGT/ptr-observatory).
 
 ## Architecture
 

--- a/README.md
+++ b/README.md
@@ -119,7 +119,8 @@ All of the following endpoints use the base url `https://jobs.photonranch.org/jo
         - 401: unauthorized user (either not logged in or did not reserve time) 
 
 - POST `/updatejobstatus`
-    - Description: Update the status of a job. This status is typically displayed in the UI for the user to see what is currently happening. 
+    - Description: Update the status of a job, mainly used by observatory code. 
+    This status is typically displayed in the UI for the user to see what is currently happening. 
     - Authorization required: no (will be added later)
     - Query Params: none
     - Request body: 
@@ -127,7 +128,9 @@ All of the following endpoints use the base url `https://jobs.photonranch.org/jo
         - "ulid" | string | id of the job being updated
         - "newStatus" | string | new status, for example: "STARTED", "EXPOSING", "COMPLETE".
         - "secondsUntilComplete" | int | estimate of the remaining time until a future status update of "complete" is sent. An empty value will register as -1. If no time estimate is available, use value of -1.
-    - Responses: 200 if successful
+    - Responses: 
+        - 400: missing required parameter (site and job ulid) 
+        - 200: returns a JSON body with updated ulid, statusID, and secondsUntilComplete
     - Example request:
     ```python
     # python 3.6
@@ -142,9 +145,7 @@ All of the following endpoints use the base url `https://jobs.photonranch.org/jo
     response = requests.request("POST", url, data=payload)
     print(response.json())
     ```
-
     - Example response:
-
     ```python
     {
         'ResponseMetadata': {
@@ -165,7 +166,6 @@ All of the following endpoints use the base url `https://jobs.photonranch.org/jo
     }
     ```
     - The job in dynamodb has been updated to look like:
-
     ```json
     [
         {
@@ -190,10 +190,10 @@ All of the following endpoints use the base url `https://jobs.photonranch.org/jo
 - POST `/getnewjobs`
     - Description: get a list of jobs with status "UNREAD". These jobs are immediately updated with a status of "RECEIVED". 
     - Authorization required: no (will be added later)
-    - Query Params: none
     - Request body: 
         - "site" | string | site abbreviation
-    - Responses: List of job objects (json). See 'Job Syntax' above for an example.
+    - Responses: 
+        - 200: List of updated job objects (JSON). See 'Job Syntax' above for an example.
     - Example request: 
     ```python
     # python 3.6
@@ -240,11 +240,12 @@ All of the following endpoints use the base url `https://jobs.photonranch.org/jo
 - POST `/getrecentjobs`
     - Description: return a list of jobs that are no older than the provided length of time.
     - Authorization required: no (will be added later)
-    - Query Params: none
     - Request body: 
         - "site" | string | site abbreviation
         - "timeRange" | int | maximum age of jobs returned, *in milliseconds*
-    - Responses: List of job objects (json). See 'Job Syntax' above for an example.
+    - Responses: 
+        - 200: List of job objects (JSON) younger than maximum age. See 'Job Syntax' 
+        above for an example.
     - Example request: 
     ```python
     # python 3.6
@@ -278,11 +279,4 @@ All of the following endpoints use the base url `https://jobs.photonranch.org/jo
     ]
     ```
 
-    - POST `/startjob`
-    - Description: 
-    - Authorization required: No
-    - Path Params:
-    - Query Params:
-    - Request body: 
-    - Responses: 
-    - Example request: 
+## License

--- a/README.md
+++ b/README.md
@@ -1,6 +1,57 @@
-# photonranch-jobs
+# Photon Ranch Jobs
 
 This repository manages job requests between the web UI and the observatory site software.
+
+## Description
+
+(insert description here)
+
+## Architecture
+
+An architecture diagram, when created, will go here.
+
+## Dependencies
+
+Dependencies will be listed here.
+
+## Local Development
+
+Clone the repository to your local machine:
+
+```
+git clone https://github.com/LCOGT/photonranch-jobs.git
+cd photonranch-jobs
+```
+
+### Requirements
+
+You will need the [Serverless Framework](https://www.serverless.com/framework/docs/getting-started) 
+installed locally for development. For manual deployment to AWS as well as for updating dependencies, 
+you will need to install [Node](https://nodejs.org/en/), 
+[npm](https://docs.npmjs.com/downloading-and-installing-node-js-and-npm), 
+and [AWS CLI](https://docs.aws.amazon.com/cli/latest/userguide/getting-started-install.html), 
+configuring with your own AWS credentials.
+
+### Deployment
+
+This project currently has two stages, `dev` (currently treated as the production stage) and `test`. 
+For manual deployment on your local machine, you'll need to fill out the 
+`public_key` and `secrets.json` with the required information, and install packages:
+
+```
+npm install
+serverless plugin install --name serverless-python-requirements
+```
+
+To deploy, run:
+
+```
+serverless deploy --stage {stage}
+```
+
+### Testing
+
+Instructions to manually run tests will be detailed here.
 
 ## Job Syntax
 
@@ -62,7 +113,10 @@ All of the following endpoints use the base url `https://jobs.photonranch.org/jo
         - "optional_params" | json | additional parameters for the job
         - "user_name" | string | the readable username, used for display
         - "user_id" | string | unique id for the user
-    - Response data: returns a copy of the job that was added to the jobs database. 
+    - Responses: 
+        - 200: returns a copy of the job that was added to the jobs database
+        - 400: missing required key in body
+        - 401: unauthorized user (either not logged in or did not reserve time) 
 
 - POST `/updatejobstatus`
     - Description: Update the status of a job. This status is typically displayed in the UI for the user to see what is currently happening. 
@@ -73,7 +127,7 @@ All of the following endpoints use the base url `https://jobs.photonranch.org/jo
         - "ulid" | string | id of the job being updated
         - "newStatus" | string | new status, for example: "STARTED", "EXPOSING", "COMPLETE".
         - "secondsUntilComplete" | int | estimate of the remaining time until a future status update of "complete" is sent. An empty value will register as -1. If no time estimate is available, use value of -1.
-    - Response data: 200 if successful
+    - Responses: 200 if successful
     - Example request:
     ```python
     # python 3.6
@@ -139,7 +193,7 @@ All of the following endpoints use the base url `https://jobs.photonranch.org/jo
     - Query Params: none
     - Request body: 
         - "site" | string | site abbreviation
-    - Response data: List of job objects (json). See 'Job Syntax' above for an example.
+    - Responses: List of job objects (json). See 'Job Syntax' above for an example.
     - Example request: 
     ```python
     # python 3.6
@@ -190,7 +244,7 @@ All of the following endpoints use the base url `https://jobs.photonranch.org/jo
     - Request body: 
         - "site" | string | site abbreviation
         - "timeRange" | int | maximum age of jobs returned, *in milliseconds*
-    - Response data: List of job objects (json). See 'Job Syntax' above for an example.
+    - Responses: List of job objects (json). See 'Job Syntax' above for an example.
     - Example request: 
     ```python
     # python 3.6
@@ -223,3 +277,12 @@ All of the following endpoints use the base url `https://jobs.photonranch.org/jo
         }
     ]
     ```
+
+    - POST `/startjob`
+    - Description: 
+    - Authorization required: No
+    - Path Params:
+    - Query Params:
+    - Request body: 
+    - Responses: 
+    - Example request: 

--- a/serverless.yml
+++ b/serverless.yml
@@ -233,26 +233,6 @@ functions:
               - X-Amz-User-Agent
               - Access-Control-Allow-Origin
               - Access-Control-Allow-Credentials
-  startJob:
-    handler: src/handler.startJob
-    events:
-      - http:
-          path: startjob
-          method: post
-          #authorizer:
-            #name: authorizerFunc
-            #resultTtlInSeconds: 0 # Don't cache the policy or other tasks will fail!
-          cors:
-            origin: '*'
-            headers:
-              - Content-Type
-              - X-Amz-Date
-              - Authorization
-              - X-Api-Key
-              - X-Amz-Security-Token
-              - X-Amz-User-Agent
-              - Access-Control-Allow-Origin
-              - Access-Control-Allow-Credentials
   authorizerFunc: 
     handler: src/authorizer.auth
 

--- a/src/authorizer.py
+++ b/src/authorizer.py
@@ -17,6 +17,8 @@ AUTH0_CLIENT_PUBLIC_KEY = os.getenv('AUTH0_CLIENT_PUBLIC_KEY')
 
 def userScheduledNow(user_id, site):
     '''
+    (Can this be deleted then??)
+    
     NOTE: not in use. Replaced by calendar_blocks_user_commands.
 
     Check if a user is currently scheduled for the given site by referencing the


### PR DESCRIPTION
Updated readme and described handler functions. Additionally got rid of unused API endpoint `/startjobs`, since it did the same thing as `/updatejobstatus` and didn't seem to be used anywhere in the observatory code. (Please correct me if I'm wrong, but I looked through `ptr-observatory` and the status of "STARTED" seemed to only be updated using `/updatejobstatus` instead of `/startjobs`. Is there any other place this endpoint might be used?)

Still to go on the readme are an architecture diagram, dependencies, testing, and license. Still to go otherwise involves fixing the stage issues, updating dependencies (which will likely allow us to get rid of the two __init__.py files), as well as potential other code cleanup described in `handlers.py`.

Note that this repository uses a hardcoded calendar API url which will need to be worked around as we update stages in other repositories.